### PR TITLE
Fix case sensitivity in word wrap script

### DIFF
--- a/dist/wrap-word/_test.html
+++ b/dist/wrap-word/_test.html
@@ -19,6 +19,10 @@
             .js-wrapped-word.--last-word {
                 color: orchid;
             }
+
+            .test-text-transform {
+                text-transform: uppercase;
+            }
         </style>
     </head>
     <body>
@@ -113,11 +117,7 @@
             Contains unsupported mode
         </div>
 
-        <!-- htmlhint inline-style-disabled:false -->
-        <div
-            data-trigger-word-wrap="first last"
-            style="text-transform: uppercase"
-        >
+        <div class="test-text-transform" data-trigger-word-wrap="first last">
             Style changes word case
         </div>
     </body>

--- a/dist/wrap-word/_test.html
+++ b/dist/wrap-word/_test.html
@@ -112,5 +112,13 @@
         <div data-trigger-word-wrap="first nope last">
             Contains unsupported mode
         </div>
+
+        <!-- htmlhint inline-style-disabled:false -->
+        <div
+            data-trigger-word-wrap="first last"
+            style="text-transform: uppercase"
+        >
+            Style changes word case
+        </div>
     </body>
 </html>


### PR DESCRIPTION
Word wrapping failed when the targeted element used `text-transform: uppercase` because the `innerText` and raw HTML didn't match.